### PR TITLE
Fixed thumbnails being typed as string per API specs.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,20 @@ declare namespace search {
     key?: string;
   }
 
+  export interface YouTubeThumbnail {
+    url: string;
+    width: number;
+    height: number;
+  }
+
+  export interface YouTubeSearchResultThumbnails {
+    default?: YouTubeThumbnail;
+    medium?: YouTubeThumbnail;
+    high?: YouTubeThumbnail;
+    standard?: YouTubeThumbnail;
+    maxres?: YouTubeThumbnail;
+  }
+
   export interface YouTubeSearchResults {
     id: string;
     link: string;
@@ -43,7 +57,7 @@ declare namespace search {
     channelId: string;
     title: string;
     description: string;
-    thumbnails: string;
+    thumbnails: YouTubeSearchResultThumbnails;
   }
 
   export interface YouTubeSearchPageResults {


### PR DESCRIPTION
Fix for #22 to conform with https://developers.google.com/youtube/v3/docs/thumbnails