### PR TITLE
TypeScript fix + Change to promises

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import {YouTubeSearchPageResults, YouTubeSearchResults} from "./index";
 
 declare namespace search {
   export interface YouTubeSearchOptions {
@@ -73,6 +74,6 @@ declare function search(
   term: string,
   opts: search.YouTubeSearchOptions,
   cb?: (err: Error, result?: search.YouTubeSearchResults[], pageInfo?: search.YouTubeSearchPageResults) => void
-): Promise<(result: search.YouTubeSearchResults[], pageInfo?: search.YouTubeSearchPageResults)>;
+): Promise<{results: YouTubeSearchResults[], pageInfo: YouTubeSearchPageResults}>;
 
 export = search;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import {YouTubeSearchPageResults, YouTubeSearchResults} from "./index";
-
 declare namespace search {
   export interface YouTubeSearchOptions {
     fields?: string;
@@ -74,6 +72,6 @@ declare function search(
   term: string,
   opts: search.YouTubeSearchOptions,
   cb?: (err: Error, result?: search.YouTubeSearchResults[], pageInfo?: search.YouTubeSearchPageResults) => void
-): Promise<{results: YouTubeSearchResults[], pageInfo: YouTubeSearchPageResults}>;
+): Promise<{results: search.YouTubeSearchResults[], pageInfo: search.YouTubeSearchPageResults}>;
 
 export = search;

--- a/index.js
+++ b/index.js
@@ -46,9 +46,9 @@ module.exports = function search (term, opts, cb) {
 
   if (!cb) {
     return new Promise(function (resolve, reject) {
-      search(term, opts, function (err, info) {
+      search(term, opts, function (err, results, pageInfo) {
         if (err) return reject(err)
-        resolve(info)
+        resolve({results: results, pageInfo: pageInfo})
       })
     })
   }

--- a/tests/test-search.js
+++ b/tests/test-search.js
@@ -16,8 +16,8 @@ test('basic', (t) => {
 test('promise', (t) => {
   var p = search('jsconf', { key: key })
   t.ok(p)
-  p.then((results) => {
-    t.equals(results.length, 30, '30 results')
+  p.then((result) => {
+    t.equals(result.results.length, 30, '30 results')
     t.end()
   })
 })


### PR DESCRIPTION
Fixes invalid TypeScript in index.d.ts.

Also noticed that the Promise doesn't return the pageInfo object but only the search results.
In order to fix this I had to create a new object:
`{results: YoutubeSearchResults[], pageInfo: YouTubeSearchPageResults}` 
that wraps them both (since promises don't allow multiple objects to be returned when resolving)

Edit: Reference issue https://github.com/MaxGfeller/youtube-search/issues/41